### PR TITLE
IncompleteValue: label & identifier, TypeConstraint: onValue, isA representation

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -453,10 +453,10 @@ function constraintToHierarchyJSON(constraint) {
   } else if (constraint.constructor.name === "IncludesCodeConstraint") {
 	  result['code'] = conceptToHierarchyJSON(constraint.code); // *Concept
   } else if (constraint.constructor.name === "TypeConstraint") {
-    result['isA'] = constraint.isA;
+    result['isA'] = identifierToHierarchyJSON(constraint.isA);
     result['onValue'] = constraint.onValue;
   } else if (constraint.constructor.name === "IncludesTypeConstraint") {
-    result['isA'] = constraint.isA;
+    result['isA'] = identifierToHierarchyJSON(constraint.isA);
   } else if (constraint.constructor.name === "BooleanConstraint") {
 	    result['value'] = constraint.value;
   } else if (constraint.constructor.name === "CardConstraint") {

--- a/lib/export.js
+++ b/lib/export.js
@@ -23,7 +23,7 @@
 // 1{ label: SHR, type: SHR}
 //   2{ label: Namespaces, type: Namespaces}
 //		3{  label: <namespace>, type: Namespace, description: <description>, grammarVersion: *Version or [ *Version, ... ] }
-//			4{  label: <identifier.name>, type: DataElement, isEntry: <isEntry>, concepts: *Concepts, description: <description>,
+//			4{  label: <identifier.name>, type: DataElement, isEntry: <isEntry>, isAbstract: <isAbstract>, concepts: *Concepts, description: <description>,
 //				basedOn: *Identifiers, value: *Value }
 //				5 *Value
 //   2{ label: Value Sets, type:ValueSets}
@@ -48,13 +48,14 @@
 //							constraints:*Constraints,
 //							text:<text> }
 // *IncompleteValue		= { type:"Incomplete", min: <min>, max: <max> but if max=* then this attribute left out,
-//							constraints:*Constraints }
+//							constraints:*Constraints,
+//              label:<identifier.namespace>":"<identifier.name>, identifier: *Identifier }
 // *Constraints			= [ *Constraint ]
 // *Constraint			= *ValueSetConstraint or *CodeConstraint or *TypeConstraint or *CardConstraint
 // *ValueSetConstraint 	= { type="ValueSetConstraint", valueset=<valueSet>, path=<path> as string with : separator }
 // *CodeConstraint		= { type="CodeConstraint", code=<code>, path=<path> as string with : separator }
 // *IncludesCodeConstraint= { type="IncludesCodeConstraint", code=<code>, path=<path> as string with : separator }
-// *TypeConstraint 		= { type="TypeConstraint", isA=<isA>, path=<path> as string with : separator }
+// *TypeConstraint 		= { type="TypeConstraint", isA=<isA>, onValue=<onValue>, path=<path> as string with : separator }
 // *BooleanConstraint	= { type="BooleanConstraint", value=<value>, path=<path> as string with : separator }
 // *CardConstraint		= { type="CardConstraint", min=<card.min>, max=<card.max> unless unbounded,
 //							path=<path> as string with : separator }
@@ -300,7 +301,7 @@ function grammarVersionsToHierarchyJSON(grammarVersions) {
 
 // *DataElement
 function definitionToHierarchyJSON(def) {
-//	4{  label: <identifier.name>, type: "DataElement", isEntry: <isEntry>, concepts: *Concepts, description: <description>,
+//	4{  label: <identifier.name>, type: "DataElement", isEntry: <isEntry>, isAbstract: <isAbstract>, concepts: *Concepts, description: <description>,
 //		basedOn: *Identifiers, value: *Value }
 //		5 *Value
 
@@ -381,7 +382,8 @@ function valueToHierarchyJSON(value) {
   //							constraints:*Constraints,
   //							text:<text> }
   // *IncompleteValue		= { type:"Incomplete", min: <min>, max: <max> but if max=* then this attribute left out,
-  //							constraints:*Constraints }
+  //							constraints:*Constraints,
+  //              label:<identifier.namespace>":"<identifier.name>, identifier: *Identifier }
 
   const result = {};
   const card = value.card;
@@ -411,6 +413,8 @@ function valueToHierarchyJSON(value) {
     result['text'] = value.text;
   } else if (value.constructor.name === "IncompleteValue") {
     result['type'] = 'Incomplete';
+    result['label'] = identifierToString(value.identifier);
+    result['identifier'] = identifierToHierarchyJSON(value.identifier);
   } else {
     logger.error('Unknown type for value \'%s\'', value.constructor.name);
     result['type'] = value.constructor.name;
@@ -435,7 +439,7 @@ function constraintToHierarchyJSON(constraint) {
   // *ValueSetConstraint 	= { type="ValueSetConstraint", valueset=<valueSet>, path=<path> as string with : separator }
   // *CodeConstraint		= { type="CodeConstraint", code=<code>, path=<path> as string with : separator }
   // *IncludesCodeConstraint= { type="IncludesCodeConstraint", code=<code>, path=<path> as string with : separator }
-  // *TypeConstraint 		= { type="TypeConstraint", isA=<isA>, path=<path> as string with : separator }
+  // *TypeConstraint 		= { type="TypeConstraint", isA=<isA>, onValue=<onValue>, path=<path> as string with : separator }
   // *BooleanConstraint		= { type="BooleanConstraint", value=<value>, path=<path> as string with : separator }
   // *CardConstraint		= { type="CardConstraint", min=<card.min>, max=<card.max> unless unbounded,
   //							path=<path> as string with : separator }
@@ -450,6 +454,7 @@ function constraintToHierarchyJSON(constraint) {
 	  result['code'] = conceptToHierarchyJSON(constraint.code); // *Concept
   } else if (constraint.constructor.name === "TypeConstraint") {
     result['isA'] = constraint.isA;
+    result['onValue'] = constraint.onValue;
   } else if (constraint.constructor.name === "IncludesTypeConstraint") {
     result['isA'] = constraint.isA;
   } else if (constraint.constructor.name === "BooleanConstraint") {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-export",
-  "version": "5.0.0-beta.4",
+  "version": "5.0.0-beta.5",
   "description": "Exports SHR data elements from SHR models to JSON",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fixes issues #13 and #14 by adding the missing label/identifier to IncompleteValues and adding the missing onValue value (boolean) to TypeConstraints.  These were discovered during the json2cameo effort.

**UPDATE**: I've also just pushed the fix for #17 to this PR.  This changes the value of `isA` properties to be consistent with the representation of how identifiers are serialized elsewhere in the JSON.

*Example of IncompleteValue Fix*

Now, instead of the following, which loses the `NonOccurrenceModifier` context entirely:
```json
{
    "constraints": [
    {
        "type": "ValueSetConstraint",
        "valueset": "http://standardhealthrecord.org/shr/medication/vs/ReasonMedicationNotUsedVS",
        "bindingStrength": "REQUIRED",
        "path": "shr.core.Reason"
    }
    ],
    "type": "Incomplete"
}
```

We have:
```json
{
    "constraints": [
    {
        "type": "ValueSetConstraint",
        "valueset": "http://standardhealthrecord.org/shr/medication/vs/ReasonMedicationNotUsedVS",
        "bindingStrength": "REQUIRED",
        "path": "shr.core.Reason"
    }
    ],
    "type": "Incomplete",
    "label": "shr.base:NonOccurrenceModifier",
    "identifier": {
        "label": "NonOccurrenceModifier",
        "type": "Identifier",
        "namespace": "shr.base"
    }
}
```