### PR TITLE
5.0.0

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -75,6 +75,7 @@ function setLogger(bunyanLogger) {
   rootLogger = logger = bunyanLogger;
 }
 
+
 // *SHR
 function exportToJSON(specifications) {
 // 1{ label: SHR, type: SHR}
@@ -313,6 +314,7 @@ function definitionToHierarchyJSON(def) {
     result['label'] = def.identifier.name;
     //result['identifier'] = identifierToHierarchyJSON(def.identifier);
     result['isEntry'] = def.isEntry;
+    result['isAbstract'] = def.isAbstract;
     result['concepts'] = conceptsToHierarchyJSON(def.concepts); // *Concepts
     result['description'] = def.description;
     //result['grammarVersion'] = def.grammarVersion;
@@ -441,6 +443,7 @@ function constraintToHierarchyJSON(constraint) {
   result['type'] = constraint.constructor.name;
   if (constraint.constructor.name === "ValueSetConstraint") {
     result['valueset'] = constraint.valueSet;
+    result['bindingStrength'] = constraint.bindingStrength;
   } else if (constraint.constructor.name === "CodeConstraint") {
     result['code'] = conceptToHierarchyJSON(constraint.code); // *Concept
   } else if (constraint.constructor.name === "IncludesCodeConstraint") {

--- a/lib/export.js
+++ b/lib/export.js
@@ -453,10 +453,10 @@ function constraintToHierarchyJSON(constraint) {
   } else if (constraint.constructor.name === "IncludesCodeConstraint") {
 	  result['code'] = conceptToHierarchyJSON(constraint.code); // *Concept
   } else if (constraint.constructor.name === "TypeConstraint") {
-    result['isA'] = constraint.isA;
+    result['isA'] = identifierToHierarchyJSON(constraint.isA);
     result['onValue'] = constraint.onValue;
   } else if (constraint.constructor.name === "IncludesTypeConstraint") {
-    result['isA'] = constraint.isA;
+    result['isA'] = identifierToHierarchyJSON(constraint.isA);
   } else if (constraint.constructor.name === "BooleanConstraint") {
 	    result['value'] = constraint.value;
   } else if (constraint.constructor.name === "CardConstraint") {

--- a/lib/export.js
+++ b/lib/export.js
@@ -23,7 +23,7 @@
 // 1{ label: SHR, type: SHR}
 //   2{ label: Namespaces, type: Namespaces}
 //		3{  label: <namespace>, type: Namespace, description: <description>, grammarVersion: *Version or [ *Version, ... ] }
-//			4{  label: <identifier.name>, type: DataElement, isEntry: <isEntry>, concepts: *Concepts, description: <description>,
+//			4{  label: <identifier.name>, type: DataElement, isEntry: <isEntry>, isAbstract: <isAbstract>, concepts: *Concepts, description: <description>,
 //				basedOn: *Identifiers, value: *Value }
 //				5 *Value
 //   2{ label: Value Sets, type:ValueSets}
@@ -48,13 +48,14 @@
 //							constraints:*Constraints,
 //							text:<text> }
 // *IncompleteValue		= { type:"Incomplete", min: <min>, max: <max> but if max=* then this attribute left out,
-//							constraints:*Constraints }
+//							constraints:*Constraints,
+//              label:<identifier.namespace>":"<identifier.name>, identifier: *Identifier }
 // *Constraints			= [ *Constraint ]
 // *Constraint			= *ValueSetConstraint or *CodeConstraint or *TypeConstraint or *CardConstraint
 // *ValueSetConstraint 	= { type="ValueSetConstraint", valueset=<valueSet>, path=<path> as string with : separator }
 // *CodeConstraint		= { type="CodeConstraint", code=<code>, path=<path> as string with : separator }
 // *IncludesCodeConstraint= { type="IncludesCodeConstraint", code=<code>, path=<path> as string with : separator }
-// *TypeConstraint 		= { type="TypeConstraint", isA=<isA>, path=<path> as string with : separator }
+// *TypeConstraint 		= { type="TypeConstraint", isA=<isA>, onValue=<onValue>, path=<path> as string with : separator }
 // *BooleanConstraint	= { type="BooleanConstraint", value=<value>, path=<path> as string with : separator }
 // *CardConstraint		= { type="CardConstraint", min=<card.min>, max=<card.max> unless unbounded,
 //							path=<path> as string with : separator }
@@ -300,7 +301,7 @@ function grammarVersionsToHierarchyJSON(grammarVersions) {
 
 // *DataElement
 function definitionToHierarchyJSON(def) {
-//	4{  label: <identifier.name>, type: "DataElement", isEntry: <isEntry>, concepts: *Concepts, description: <description>,
+//	4{  label: <identifier.name>, type: "DataElement", isEntry: <isEntry>, isAbstract: <isAbstract>, concepts: *Concepts, description: <description>,
 //		basedOn: *Identifiers, value: *Value }
 //		5 *Value
 
@@ -381,7 +382,8 @@ function valueToHierarchyJSON(value) {
   //							constraints:*Constraints,
   //							text:<text> }
   // *IncompleteValue		= { type:"Incomplete", min: <min>, max: <max> but if max=* then this attribute left out,
-  //							constraints:*Constraints }
+  //							constraints:*Constraints,
+  //              label:<identifier.namespace>":"<identifier.name>, identifier: *Identifier }
 
   const result = {};
   const card = value.card;
@@ -411,6 +413,8 @@ function valueToHierarchyJSON(value) {
     result['text'] = value.text;
   } else if (value.constructor.name === "IncompleteValue") {
     result['type'] = 'Incomplete';
+    result['label'] = identifierToString(value.identifier);
+    result['identifier'] = identifierToHierarchyJSON(value.identifier);
   } else {
     logger.error('Unknown type for value \'%s\'', value.constructor.name);
     result['type'] = value.constructor.name;
@@ -435,7 +439,7 @@ function constraintToHierarchyJSON(constraint) {
   // *ValueSetConstraint 	= { type="ValueSetConstraint", valueset=<valueSet>, path=<path> as string with : separator }
   // *CodeConstraint		= { type="CodeConstraint", code=<code>, path=<path> as string with : separator }
   // *IncludesCodeConstraint= { type="IncludesCodeConstraint", code=<code>, path=<path> as string with : separator }
-  // *TypeConstraint 		= { type="TypeConstraint", isA=<isA>, path=<path> as string with : separator }
+  // *TypeConstraint 		= { type="TypeConstraint", isA=<isA>, onValue=<onValue>, path=<path> as string with : separator }
   // *BooleanConstraint		= { type="BooleanConstraint", value=<value>, path=<path> as string with : separator }
   // *CardConstraint		= { type="CardConstraint", min=<card.min>, max=<card.max> unless unbounded,
   //							path=<path> as string with : separator }
@@ -450,6 +454,7 @@ function constraintToHierarchyJSON(constraint) {
 	  result['code'] = conceptToHierarchyJSON(constraint.code); // *Concept
   } else if (constraint.constructor.name === "TypeConstraint") {
     result['isA'] = constraint.isA;
+    result['onValue'] = constraint.onValue;
   } else if (constraint.constructor.name === "IncludesTypeConstraint") {
     result['isA'] = constraint.isA;
   } else if (constraint.constructor.name === "BooleanConstraint") {

--- a/lib/export.js
+++ b/lib/export.js
@@ -56,6 +56,8 @@
 // *CodeConstraint		= { type="CodeConstraint", code=<code>, path=<path> as string with : separator }
 // *IncludesCodeConstraint= { type="IncludesCodeConstraint", code=<code>, path=<path> as string with : separator }
 // *TypeConstraint 		= { type="TypeConstraint", isA=<isA>, onValue=<onValue>, path=<path> as string with : separator }
+// *IncludesTypeConstraint 		= { type="IncludesTypeConstraint", isA=<isA>, min=<card.min>, max=<card.max> unless unbounded, 
+//              path = <path> as string with : separator }
 // *BooleanConstraint	= { type="BooleanConstraint", value=<value>, path=<path> as string with : separator }
 // *CardConstraint		= { type="CardConstraint", min=<card.min>, max=<card.max> unless unbounded,
 //							path=<path> as string with : separator }
@@ -457,6 +459,13 @@ function constraintToHierarchyJSON(constraint) {
     result['onValue'] = constraint.onValue;
   } else if (constraint.constructor.name === "IncludesTypeConstraint") {
     result['isA'] = identifierToHierarchyJSON(constraint.isA);
+    const card = constraint.card;
+    if (card) {
+      result['min'] = card.min;
+      if (!card.isMaxUnbounded) {
+        result['max'] = card.max;
+      }
+    }
   } else if (constraint.constructor.name === "BooleanConstraint") {
 	    result['value'] = constraint.value;
   } else if (constraint.constructor.name === "CardConstraint") {

--- a/lib/export.js
+++ b/lib/export.js
@@ -447,8 +447,10 @@ function constraintToHierarchyJSON(constraint) {
   } else if (constraint.constructor.name === "CodeConstraint") {
     result['code'] = conceptToHierarchyJSON(constraint.code); // *Concept
   } else if (constraint.constructor.name === "IncludesCodeConstraint") {
-	result['code'] = conceptToHierarchyJSON(constraint.code); // *Concept
+	  result['code'] = conceptToHierarchyJSON(constraint.code); // *Concept
   } else if (constraint.constructor.name === "TypeConstraint") {
+    result['isA'] = constraint.isA;
+  } else if (constraint.constructor.name === "IncludesTypeConstraint") {
     result['isA'] = constraint.isA;
   } else if (constraint.constructor.name === "BooleanConstraint") {
 	    result['value'] = constraint.value;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-export",
-  "version": "5.0.0-beta.3",
+  "version": "5.0.0-beta.4",
   "description": "Exports SHR data elements from SHR models to JSON",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-export",
-  "version": "5.0.0-beta.2",
+  "version": "5.0.0-beta.3",
   "description": "Exports SHR data elements from SHR models to JSON",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-export",
-  "version": "5.0.0-beta.4",
+  "version": "5.0.0-beta.5",
   "description": "Exports SHR data elements from SHR models to JSON",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-export",
-  "version": "5.0.0-beta.5",
+  "version": "5.0.0",
   "description": "Exports SHR data elements from SHR models to JSON",
   "author": "",
   "license": "Apache-2.0",
@@ -18,12 +18,12 @@
   },
   "dependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "beta"
+    "shr-models": "^5.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
-    "shr-test-helpers": "beta"
+    "shr-test-helpers": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-export",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "description": "Exports SHR data elements from SHR models to JSON",
   "author": "",
   "license": "Apache-2.0",
@@ -18,12 +18,12 @@
   },
   "dependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": ">=5.0.0-beta <5.1.0"
+    "shr-models": "beta"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
-    "shr-test-helpers": ">=5.0.0-beta <5.1.0"
+    "shr-test-helpers": "beta"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-export",
-  "version": "4.3.3",
+  "version": "5.0.0-beta.1",
   "description": "Exports SHR data elements from SHR models to JSON",
   "author": "",
   "license": "Apache-2.0",
@@ -18,12 +18,12 @@
   },
   "dependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "^4.2.1"
+    "shr-models": ">=5.0.0-beta <5.1.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
-    "shr-test-helpers": "^4.2.1"
+    "shr-test-helpers": ">=5.0.0-beta <5.1.0"
   }
 }

--- a/test/fixtures/Choice.json
+++ b/test/fixtures/Choice.json
@@ -1,108 +1,115 @@
 {
-  "label": "SHR",
-  "type": "SHR",
-  "children": [
-    {
-      "label": "Namespaces",
-      "type": "Namespaces",
-      "children": [
-        {
-      "label": "shr.test",
-      "type": "Namespace",
-      "children": [
+	"label": "SHR",
+	"type": "SHR",
+	"children": [
 		{
-		  "type": "DataElement",
-		  "label": "Choice",
-		  "isEntry": true,
-		  "children" : [],
-		  "concepts": [
-		  ],
-		  "description": "It is an element with a choice",
-		  "value": {
-			"constraints" : [],
-		    "max": 1,
-		    "min": 1,
-		    "type": "ChoiceValue",
-			"value": [
-			  {
-				"label": "primitive:string",
-			    "max": 1,
-			    "min": 1,
-			    "type": "IdentifiableValue",
-				"constraints" : [],
-				"identifier": {
-				  "label": "string",
-				  "type": "Identifier",
-				  "namespace": "primitive"
-				}
-			  },
-			  {
-                "constraints": [
-                	{
-                    	"path": "",
-                        "type": "ValueSetConstraint",
-                        "valueset": "http://standardhealthrecord.org/test/vs/CodeChoice"
-					}
-				],
-				"identifier": {
-      				"label": "code",
-					"namespace": "primitive",
-					"type": "Identifier"
-				},
-      			"label": "primitive:code",
-				"min": 0,
-				"type": "IdentifiableValue"
-			  },
-			  {
-      			"constraints": [],
-				"identifier": {
-					"label": "Coded",
-					"namespace": "shr.test",
-					"type": "Identifier"
-				},
-      			"label": "shr.test:Coded",
-                "max": 1,
-				"min": 1,
-				"type": "IdentifiableValue"
-			  }
-			]
-		  }
-		},
-        {
-          "concepts": [],
-          "description": "It is a coded element",
-          "isEntry": true,
-		  "children" : [],
-          "label": "Coded",
-          "type": "DataElement",
-          "value" : {
-			"constraints": [
+			"label": "Namespaces",
+			"type": "Namespaces",
+			"children": [
 				{
-      				"path": "",
-					"type": "ValueSetConstraint",
-					"valueset": "http://standardhealthrecord.org/test/vs/Coded"
+					"label": "shr.test",
+					"type": "Namespace",
+					"children": [
+						{
+							"type": "DataElement",
+							"label": "Choice",
+							"isEntry": true,
+							"isAbstract": false,
+							"children": [],
+							"concepts": [],
+							"description": "It is an element with a choice",
+							"value": {
+								"constraints": [],
+								"max": 1,
+								"min": 1,
+								"type": "ChoiceValue",
+								"value": [
+									{
+										"label": "primitive:string",
+										"max": 1,
+										"min": 1,
+										"type": "IdentifiableValue",
+										"constraints": [],
+										"identifier": {
+											"label": "string",
+											"type": "Identifier",
+											"namespace": "primitive"
+										}
+									},
+									{
+										"constraints": [
+											{
+												"path": "",
+												"bindingStrength": "REQUIRED",
+												"type": "ValueSetConstraint",
+												"valueset": "http://standardhealthrecord.org/test/vs/CodeChoice"
+											}
+										],
+										"identifier": {
+											"label": "code",
+											"namespace": "primitive",
+											"type": "Identifier"
+										},
+										"label": "primitive:code",
+										"min": 0,
+										"type": "IdentifiableValue"
+									},
+									{
+										"constraints": [],
+										"identifier": {
+											"label": "Coded",
+											"namespace": "shr.test",
+											"type": "Identifier"
+										},
+										"label": "shr.test:Coded",
+										"max": 1,
+										"min": 1,
+										"type": "IdentifiableValue"
+									}
+								]
+							}
+						},
+						{
+							"concepts": [],
+							"description": "It is a coded element",
+							"isEntry": true,
+							"isAbstract": false,
+							"children": [],
+							"label": "Coded",
+							"type": "DataElement",
+							"value": {
+								"constraints": [
+									{
+										"path": "",
+										"bindingStrength": "REQUIRED",
+										"type": "ValueSetConstraint",
+										"valueset": "http://standardhealthrecord.org/test/vs/Coded"
+									}
+								],
+								"identifier": {
+									"label": "code",
+									"namespace": "primitive",
+									"type": "Identifier"
+								},
+								"label": "primitive:code",
+								"max": 1,
+								"min": 1,
+								"type": "IdentifiableValue"
+							}
+						}
+					]
 				}
-		  	],
-      	  	"identifier": {
-		  		"label": "code",
-		  		"namespace": "primitive",
-				"type": "Identifier"
-		  	},
-		  	"label": "primitive:code",
-		  	"max": 1,
-		  	"min": 1,
-		  	"type": "IdentifiableValue"
-		  }
-        }
-	  ]
-	}
+			]
+		},
+		{
+			"label": "Value Sets",
+			"type": "ValueSets",
+			"children": []
+		},
+		{
+			"label": "Code Systems",
+			"type": "CodeSystems",
+			"children": []
+		}
 	]
-	},
-	{ "label": "Value Sets",
-	  "type" : "ValueSets",
-	  "children": []},
-	{ "label": "Code Systems",
-	  "type" : "CodeSystems",
-	  "children": []}
-  ]
 }

--- a/test/fixtures/ChoiceOfChoice.json
+++ b/test/fixtures/ChoiceOfChoice.json
@@ -14,6 +14,7 @@
 		  "type": "DataElement",
 		  "label": "ChoiceOfChoice",
 		  "isEntry": true,
+		  "isAbstract": false,
 		  "children" : [],
 		  "concepts": [],
 		  "description": "It is an element with a choice containing a choice",
@@ -71,9 +72,10 @@
       				"constraints": [
 						{
 							"path": "",
-      						"type": "ValueSetConstraint",
-      						"valueset": "http://standardhealthrecord.org/test/vs/CodeChoice"
-      					}
+							"bindingStrength": "REQUIRED",
+							"type": "ValueSetConstraint",
+							"valueset": "http://standardhealthrecord.org/test/vs/CodeChoice"
+						}
       				],
 					"identifier": {
       					"label": "code",

--- a/test/fixtures/Coded.json
+++ b/test/fixtures/Coded.json
@@ -15,18 +15,20 @@
           "concepts": [],
           "description": "It is a coded element",
           "isEntry": true,
+          "isAbstract": false,
           "label": "Coded",
           "type": "DataElement",
           "value": {
           	"constraints" : [
           		{
-                    "path": "",
-                    "type": "ValueSetConstraint",
- 					"valueset": "http://standardhealthrecord.org/test/vs/Coded"
-          		}
-          	],
+                "path": "",
+                "bindingStrength": "REQUIRED",
+                "type": "ValueSetConstraint",
+                "valueset": "http://standardhealthrecord.org/test/vs/Coded"
+              }
+            ],
             "identifier": {
-            	"label": "code",
+              "label": "code",
                 "namespace": "primitive",
                 "type": "Identifier"
              },

--- a/test/fixtures/ElementValue.json
+++ b/test/fixtures/ElementValue.json
@@ -14,6 +14,7 @@
   "type": "DataElement",
   "label": "ElementValue",
   "isEntry": true,
+  "isAbstract": false,
   "children" : [],
   "concepts": [],
   "description": "It is an element with an element value",
@@ -34,6 +35,7 @@
   "type": "DataElement",
   "label": "Simple",
   "isEntry": true,
+  "isAbstract": false,
   "children" : [],
   "concepts": [
     {

--- a/test/fixtures/ForeignElementValue.json
+++ b/test/fixtures/ForeignElementValue.json
@@ -14,6 +14,7 @@
   "type": "DataElement",
   "label": "ForeignElementValue",
   "isEntry": true,
+  "isAbstract": false,
   "children" : [],
   "concepts": [],
   "description": "It is an element with a foreign element value",
@@ -40,6 +41,7 @@
   "type": "DataElement",
   "label": "Simple",
   "isEntry": true,
+  "isAbstract": false,
   "children" : [],
   "concepts": [
     {

--- a/test/fixtures/ForeignSimple.json
+++ b/test/fixtures/ForeignSimple.json
@@ -14,6 +14,7 @@
   "type": "DataElement",
   "label": "Simple",
   "isEntry": true,
+  "isAbstract": false,
   "children" : [],
   "concepts": [
     {

--- a/test/fixtures/Group.json
+++ b/test/fixtures/Group.json
@@ -14,17 +14,19 @@
           "type": "DataElement",
           "label": "Coded",
           "isEntry": true,
+          "isAbstract": false,
 		  "children" : [],
           "concepts": [],
           "description": "It is a coded element",
           "value": {
       		"constraints": [
       			{
-      				"path": "",
-      				"type": "ValueSetConstraint",
-      				"valueset": "http://standardhealthrecord.org/test/vs/Coded"
-      			}
-      		],
+							"path": "",
+							"bindingStrength": "REQUIRED",
+							"type": "ValueSetConstraint",
+							"valueset": "http://standardhealthrecord.org/test/vs/Coded"
+						}
+					],
       		"identifier": {
       			"label": "code",
       			"namespace": "primitive",
@@ -39,7 +41,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "ElementValue",
-		  "isEntry": true,
+			"isEntry": true, 
+			"isAbstract": false,
 		  "children" : [],
 		  "concepts": [],
 		  "description": "It is an element with an element value",
@@ -59,7 +62,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "ForeignElementValue",
-		  "isEntry": true,
+			"isEntry": true, 
+			"isAbstract": false,
 		  "children" : [],
 		  "concepts": [],
 		  "description": "It is an element with a foreign element value",
@@ -79,7 +83,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "Group",
-		  "isEntry": true,
+			"isEntry": true,
+			"isAbstract": false,
 		  "concepts": [
 			{
 			  "label": "Foobar (http://foo.org:bar)",
@@ -171,7 +176,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "Simple",
-		  "isEntry": true,
+			"isEntry": true,
+			"isAbstract": false,
 		  "children" : [],
 		  "concepts": [
 			{
@@ -207,7 +213,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "Simple",
-		  "isEntry": true,
+			"isEntry": true, 
+			"isAbstract": false,
 		  "children" : [],
 		  "concepts": [
 			{

--- a/test/fixtures/GroupDerivative.json
+++ b/test/fixtures/GroupDerivative.json
@@ -14,16 +14,18 @@
           "type": "DataElement",
           "label": "Coded",
           "isEntry": true,
+          "isAbstract": false,
 		  "children" : [],
           "concepts": [],
           "description": "It is a coded element",
           "value": {
       		"constraints": [
       			{
-      				"path": "",
-      				"type": "ValueSetConstraint",
-      				"valueset": "http://standardhealthrecord.org/test/vs/Coded"
-      			}
+							"path": "",
+							"bindingStrength": "REQUIRED",
+							"type": "ValueSetConstraint",
+							"valueset": "http://standardhealthrecord.org/test/vs/Coded"
+						}
       		],
       		"identifier": {
       			"label": "code",
@@ -39,7 +41,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "ElementValue",
-		  "isEntry": true,
+			"isEntry": true, 
+		  "isAbstract": false,
 		  "children" : [],
 		  "concepts": [],
 		  "description": "It is an element with an element value",
@@ -59,7 +62,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "ForeignElementValue",
-		  "isEntry": true,
+			"isEntry": true, 
+			"isAbstract": false,
 		  "children" : [],
 		  "concepts": [],
 		  "description": "It is an element with a foreign element value",
@@ -79,7 +83,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "Group",
-		  "isEntry": true,
+			"isEntry": true, 
+			"isAbstract": false,
 		  "concepts": [
 			{
 			  "label": "Foobar (http://foo.org:bar)",
@@ -180,6 +185,7 @@
       		"concepts": [],
       		"description": "It is a derivative of a group of elements",
       		"isEntry": true,
+      		"isAbstract": false,
 			"label": "GroupDerivative",
       		"type": "DataElement",
       		"value": {
@@ -198,7 +204,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "Simple",
-		  "isEntry": true,
+			"isEntry": true, 
+			"isAbstract": false,
 		  "children" : [],
 		  "concepts": [
 			{
@@ -234,7 +241,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "Simple",
-		  "isEntry": true,
+			"isEntry": true, 
+			"isAbstract": false,
 		  "children" : [],
 		  "concepts": [
 			{

--- a/test/fixtures/GroupPathClash.json
+++ b/test/fixtures/GroupPathClash.json
@@ -13,7 +13,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "GroupPathClash",
-		  "isEntry": true,
+			"isEntry": true, 
+			"isAbstract": false,
 		  "concepts": [],
 		  "description": "It is a group of elements with clashing names",
 		  "children": [
@@ -46,7 +47,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "Simple",
-		  "isEntry": true,
+			"isEntry": true, 
+			"isAbstract": false,
 		  "children" : [],
 		  "concepts": [
 			{
@@ -82,7 +84,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "Simple",
-		  "isEntry": true,
+			"isEntry": true, 
+			"isAbstract": false,
 		  "children" : [],
 		  "concepts": [
 			{

--- a/test/fixtures/GroupWithChoiceOfChoice.json
+++ b/test/fixtures/GroupWithChoiceOfChoice.json
@@ -14,15 +14,17 @@
           "type": "DataElement",
           "label": "Coded",
           "isEntry": true,
+          "isAbstract": false,
 		  "children" : [],
           "concepts": [],
           "description": "It is a coded element",
           "value": {
       		"constraints": [
       			{
-      				"path": "",
-      				"type": "ValueSetConstraint",
-      				"valueset": "http://standardhealthrecord.org/test/vs/Coded"
+							"path": "",
+							"bindingStrength": "REQUIRED",
+							"type": "ValueSetConstraint",
+							"valueset": "http://standardhealthrecord.org/test/vs/Coded"
       			}
       		],
       		"identifier": {
@@ -39,7 +41,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "ElementValue",
-		  "isEntry": true,
+			"isEntry": true, 
+			"isAbstract": false,
 		  "children" : [],
 		  "concepts": [],
 		  "description": "It is an element with an element value",
@@ -59,7 +62,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "ForeignElementValue",
-		  "isEntry": true,
+			"isEntry": true, 
+			"isAbstract": false,
 		  "children" : [],
 		  "concepts": [],
 		  "description": "It is an element with a foreign element value",
@@ -79,7 +83,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "GroupWithChoiceOfChoice",
-		  "isEntry": true,
+			"isEntry": true, 
+			"isAbstract": false,
 		  "concepts": [],
 		  "description": "It is a group of elements with a choice containing a choice",
 		  "children": [
@@ -162,7 +167,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "Simple",
-		  "isEntry": true,
+			"isEntry": true, 
+			"isAbstract": false,
 		  "children" : [],
 		  "concepts": [
 			{
@@ -198,7 +204,8 @@
 		{
 		  "type": "DataElement",
 		  "label": "Simple",
-		  "isEntry": true,
+			"isEntry": true, 
+			"isAbstract": false,
 		  "children" : [],
 		  "concepts": [
 			{

--- a/test/fixtures/Simple.json
+++ b/test/fixtures/Simple.json
@@ -14,6 +14,7 @@
   "type": "DataElement",
   "label": "Simple",
   "isEntry": true,
+  "isAbstract": false,
   "children" : [],
   "concepts": [
     {

--- a/test/fixtures/SimpleReference.json
+++ b/test/fixtures/SimpleReference.json
@@ -14,6 +14,7 @@
   "type": "DataElement",
   "label": "SimpleReference",
   "isEntry": true,
+  "isAbstract": false,
   "children" : [],
   "concepts": [],
   "description": "It is a reference to a simple element",

--- a/test/fixtures/TwoDeepElementValue.json
+++ b/test/fixtures/TwoDeepElementValue.json
@@ -14,6 +14,7 @@
   "type": "DataElement",
   "label": "ElementValue",
   "isEntry": true,
+  "isAbstract": false,
   "children" : [],
   "concepts": [],
   "description": "It is an element with an element value",
@@ -34,6 +35,7 @@
   "type": "DataElement",
   "label": "Simple",
   "isEntry": true,
+  "isAbstract": false,
   "children" : [],
   "concepts": [
     {
@@ -63,6 +65,7 @@
   "type": "DataElement",
   "label": "TwoDeepElementValue",
   "isEntry": true,
+  "isAbstract": false,
   "children" : [],
   "concepts": [],
   "description": "It is an element with a two-deep element value",

--- a/yarn.lock
+++ b/yarn.lock
@@ -882,12 +882,12 @@ shelljs@^0.7.5:
     rechoir "^0.6.2"
 
 shr-models@beta:
-  version "5.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.0.0-beta.3.tgz#cd57f7fe74cb397a43e77588e1c9f69a9785791d"
+  version "5.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.0.0-beta.4.tgz#89b0c8e610a2ec52ea4f9024df76bf63051ff46f"
 
 shr-test-helpers@beta:
-  version "5.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.0.0-beta.2.tgz#21031bf9f3a5e3f57f699216e5c5fd9db2d623d2"
+  version "5.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.0.0-beta.3.tgz#e88741c7f9a9b9c2374b4e9c44d0e61b8f4127a2"
   dependencies:
     bunyan "^1.8.9"
     shr-models beta

--- a/yarn.lock
+++ b/yarn.lock
@@ -881,16 +881,16 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-models@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-4.2.1.tgz#57a067afb78ffbf8e57fd51fb34188b00fc252e6"
+"shr-models@>=5.0.0-beta <5.1.0":
+  version "5.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.0.0-beta.1.tgz#fcafa30231ded644ee42865aa84c83dc37c3310a"
 
-shr-test-helpers@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-4.2.1.tgz#327ca5840141a7ee3057cfb4b7fc0c47b32a4628"
+"shr-test-helpers@>=5.0.0-beta <5.1.0":
+  version "5.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.0.0-beta.1.tgz#26ada80d79eb270ad56d4b398cdb7a912fc3a0f0"
   dependencies:
     bunyan "^1.8.9"
-    shr-models "^4.2.1"
+    shr-models ">=5.0.0-beta <5.1.0"
 
 slice-ansi@0.0.4:
   version "0.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -881,16 +881,16 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-"shr-models@>=5.0.0-beta <5.1.0":
-  version "5.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.0.0-beta.1.tgz#fcafa30231ded644ee42865aa84c83dc37c3310a"
+shr-models@beta:
+  version "5.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.0.0-beta.3.tgz#cd57f7fe74cb397a43e77588e1c9f69a9785791d"
 
-"shr-test-helpers@>=5.0.0-beta <5.1.0":
-  version "5.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.0.0-beta.1.tgz#26ada80d79eb270ad56d4b398cdb7a912fc3a0f0"
+shr-test-helpers@beta:
+  version "5.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.0.0-beta.2.tgz#21031bf9f3a5e3f57f699216e5c5fd9db2d623d2"
   dependencies:
     bunyan "^1.8.9"
-    shr-models ">=5.0.0-beta <5.1.0"
+    shr-models beta
 
 slice-ansi@0.0.4:
   version "0.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -881,16 +881,16 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-models@beta:
-  version "5.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.0.0-beta.4.tgz#89b0c8e610a2ec52ea4f9024df76bf63051ff46f"
+shr-models@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.0.0.tgz#ddeefb62d99b630b828401d87e594803d06b9e3b"
 
-shr-test-helpers@beta:
-  version "5.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.0.0-beta.3.tgz#e88741c7f9a9b9c2374b4e9c44d0e61b8f4127a2"
+shr-test-helpers@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.0.0.tgz#7af44277aa04a988bd3dd75dde55185e2ce34f3b"
   dependencies:
     bunyan "^1.8.9"
-    shr-models beta
+    shr-models "^5.0.0"
 
 slice-ansi@0.0.4:
   version "0.0.4"


### PR DESCRIPTION
The new version 5.0.0 adds the following support to shr-json-export:
- binding strengths for value sets
- abstract elements
- includes type constraints (indicates a list should include certain sub-types)
- bug fixes