### PR TITLE
Added support for configuration.

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -125,8 +125,8 @@ function exportToJSON(specifications, configuration=[]) {
   }
 
   const shr = {
-    label:  configuration.shortHand,
-    type:   configuration.shortHand,
+    label:  configuration.projectShorthand,
+    type:   configuration.projectShorthand,
     children: [ {	label:    'Namespaces',
     		      		type:     'Namespaces',
     		      		children: namespaceResults },

--- a/lib/export.js
+++ b/lib/export.js
@@ -78,13 +78,18 @@ function setLogger(bunyanLogger) {
   rootLogger = logger = bunyanLogger;
 }
 
+var config;
 
 // *SHR
-function exportToJSON(specifications) {
+function exportToJSON(specifications, configuration=[]) {
 // 1{ label: SHR, type: SHR}
 //   2{ label: Namespaces, type: Namespaces}
 //		3{ label: <namespace>, type: "Namespace", description: <description>, grammarVersion: <grammarVersions> }
+
+  config = configuration;
+
   const namespaceResults = [], valuesetResults = [], codeSystemResults = [];
+
 
   for (const ns of specifications.namespaces.all) {
 	  namespaceResults.push(
@@ -120,17 +125,17 @@ function exportToJSON(specifications) {
   }
 
   const shr = {
-    label: 'SHR',
-    type: 'SHR',
-    children: [ {	label: 'Namespaces',
-    				type:'Namespaces',
-    				children: namespaceResults },
-    			{	label: 'Value Sets',
-    				type:'ValueSets',
-    				children: valuesetResults },
-    			{	label: 'Code Systems',
-    				type: 'CodeSystems',
-    				children: codeSystemResults }]
+    label:  configuration.shortHand,
+    type:   configuration.shortHand,
+    children: [ {	label:    'Namespaces',
+    		      		type:     'Namespaces',
+    		      		children: namespaceResults },
+    		      	{	label:    'Value Sets',
+    		      		type:     'ValueSets',
+    		      		children: valuesetResults },
+    		      	{	label:    'Code Systems',
+    		      		type:     'CodeSystems',
+    		      		children: codeSystemResults }]
     };
   return shr;
 }
@@ -567,7 +572,7 @@ function systemAndCodeToUrl(system, code) {
     default:
 	if (system.startsWith('http://hl7.org/fhir/')) {
 		url = `${system}#definition`;
-	} else if (system.startsWith('http://standardhealthrecord.org/')) {
+	} else if (system.startsWith(config.projectURL)) {
 		url = system;
 	} else {
     logger.warn('Unsupported code system: \'%s\'', system);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-export",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Exports SHR data elements from SHR models to JSON",
   "author": "",
   "license": "Apache-2.0",

--- a/test/export_test.js
+++ b/test/export_test.js
@@ -8,8 +8,13 @@ setLogger(err.logger());
 
 describe('#exportToJSON()', commonExportTests(exportSpecifications, importFixture, importErrorsFixture));
 
+function defaultConfiguration()
+{
+  return JSON.parse(fs.readFileSync(`${__dirname}/fixtures/config/defaultConfig.json`, 'utf8'));
+}
+
 function exportSpecifications(specifications) {
-  return exportToJSON(specifications);
+  return exportToJSON(specifications, defaultConfiguration());
 }
 
 function importFixture(name, ext='.json') {

--- a/test/fixtures/Choice.json
+++ b/test/fixtures/Choice.json
@@ -1,6 +1,6 @@
 {
-	"label": "SHR",
-	"type": "SHR",
+	"label": "FOOBAR",
+	"type": "FOOBAR",
 	"children": [
 		{
 			"label": "Namespaces",

--- a/test/fixtures/ChoiceOfChoice.json
+++ b/test/fixtures/ChoiceOfChoice.json
@@ -1,6 +1,6 @@
 {
-  "label": "SHR",
-  "type": "SHR",
+  "label": "FOOBAR",
+  "type": "FOOBAR",
   "children": [
     {
       "label": "Namespaces",

--- a/test/fixtures/Coded.json
+++ b/test/fixtures/Coded.json
@@ -1,6 +1,6 @@
 {
-  "label": "SHR",
-  "type": "SHR",
+  "label": "FOOBAR",
+  "type": "FOOBAR",
   "children": [
     {
       "label": "Namespaces",

--- a/test/fixtures/ElementValue.json
+++ b/test/fixtures/ElementValue.json
@@ -1,6 +1,6 @@
 {
-  "label": "SHR",
-  "type": "SHR",
+  "label": "FOOBAR",
+  "type": "FOOBAR",
   "children": [
     {
       "label": "Namespaces",

--- a/test/fixtures/ForeignElementValue.json
+++ b/test/fixtures/ForeignElementValue.json
@@ -1,6 +1,6 @@
 {
-  "label": "SHR",
-  "type": "SHR",
+  "label": "FOOBAR",
+  "type": "FOOBAR",
   "children": [
     {
       "label": "Namespaces",

--- a/test/fixtures/ForeignSimple.json
+++ b/test/fixtures/ForeignSimple.json
@@ -1,6 +1,6 @@
 {
-  "label": "SHR",
-  "type": "SHR",
+  "label": "FOOBAR",
+  "type": "FOOBAR",
   "children": [
     {
       "label": "Namespaces",

--- a/test/fixtures/Group.json
+++ b/test/fixtures/Group.json
@@ -1,6 +1,6 @@
 {
-  "label": "SHR",
-  "type": "SHR",
+  "label": "FOOBAR",
+  "type": "FOOBAR",
   "children": [
     {
       "label": "Namespaces",

--- a/test/fixtures/GroupDerivative.json
+++ b/test/fixtures/GroupDerivative.json
@@ -1,6 +1,6 @@
 {
-  "label": "SHR",
-  "type": "SHR",
+  "label": "FOOBAR",
+  "type": "FOOBAR",
   "children": [
     {
       "label": "Namespaces",

--- a/test/fixtures/GroupPathClash.json
+++ b/test/fixtures/GroupPathClash.json
@@ -1,6 +1,6 @@
 {
-  "label": "SHR",
-  "type": "SHR",
+  "label": "FOOBAR",
+  "type": "FOOBAR",
   "children": [
     {
       "label": "Namespaces",

--- a/test/fixtures/GroupWithChoiceOfChoice.json
+++ b/test/fixtures/GroupWithChoiceOfChoice.json
@@ -1,6 +1,6 @@
 {
-  "label": "SHR",
-  "type": "SHR",
+  "label": "FOOBAR",
+  "type": "FOOBAR",
   "children": [
     {
       "label": "Namespaces",

--- a/test/fixtures/Simple.json
+++ b/test/fixtures/Simple.json
@@ -1,6 +1,6 @@
 {
-  "label": "SHR",
-  "type": "SHR",
+  "label": "FOOBAR",
+  "type": "FOOBAR",
   "children": [
     {
       "label": "Namespaces",

--- a/test/fixtures/SimpleReference.json
+++ b/test/fixtures/SimpleReference.json
@@ -1,6 +1,6 @@
 {
-  "label": "SHR",
-  "type": "SHR",
+  "label": "FOOBAR",
+  "type": "FOOBAR",
   "children": [
     {
       "label": "Namespaces",

--- a/test/fixtures/TwoDeepElementValue.json
+++ b/test/fixtures/TwoDeepElementValue.json
@@ -1,6 +1,6 @@
 {
-  "label": "SHR",
-  "type": "SHR",
+  "label": "FOOBAR",
+  "type": "FOOBAR",
   "children": [
     {
       "label": "Namespaces",

--- a/test/fixtures/config/defaultConfig.json
+++ b/test/fixtures/config/defaultConfig.json
@@ -1,0 +1,12 @@
+{
+    "projectName":"The Foo Bar Standard Records",
+    "projectShorthand":"FOOBAR",
+    "projectURL":"http://foobar.com",
+    "publisher":"The Foo Bar Corporation",
+    "contact":[{
+        "telecom": [{
+          "system": "url",
+          "value": "http://foobar.com"
+        }]
+      }]
+}


### PR DESCRIPTION
PR 2 of 4

Replaces Label, Type, and default codesystem url to project specific shorthands and URLs

Edit: Needs verification of whether the code system url should be projectURL or fhirURL.